### PR TITLE
disable ln and integrate elisp lint

### DIFF
--- a/.emacs.d/my-init.el
+++ b/.emacs.d/my-init.el
@@ -6,8 +6,9 @@
 (defvar my-packages '(flycheck magit elisp-lint))
 
 (require 'package)
-(add-to-list 'package-archives
-             '("melpa-stable" . "https://stable.melpa.org/packages/") t)
+(add-to-list
+ 'package-archives
+ '("melpa-stable" . "https://stable.melpa.org/packages/") t)
 (package-initialize)
 
 (when (not package-archive-contents)

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,0 @@
-$(HOME)/.emacs.d/my-init.el: .emacs.d/my-init.el
-	mkdir -p $(HOME)/.emacs.d
-	ln -s $(abspath $<) $@

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+all:
+
+lint: elisp-lint-all
+
+EMACS_CMD=emacs
+ELISP_LINT_PATH=$(HOME)/.emacs.d/elpa/elisp-lint-0.2.0/elisp-lint.el
+ELISP_LINT_OPTION=--no-byte-compile --no-checkdoc --no-package-format
+ELISP_LINT_CMD=$(EMACS_CMD) -Q --batch -l $(ELISP_LINT_PATH) -f elisp-lint-files-batch $(ELISP_LINT_OPTION)
+elisp-lint-all: .emacs.d/my-init.el
+	emacs --version
+	$(ELISP_LINT_CMD) $+


### PR DESCRIPTION
- Disable `ln -s' by make
  - It is not easy to apply for Windows environment
- Added make target "lint" to check syntax
- Resolved issues found by lint\