### PR TITLE
Work around for CI error by conflicting 2to3.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,9 @@ jobs:
       if: contains(matrix.os, 'macOS')
       run: |
         brew update
-        brew install shellcheck emacs
+        brew install shellcheck
+        rm -f /usr/local/bin/2to3
+        brew install emacs
 
     - name: Test run
       shell: bash


### PR DESCRIPTION
Installing Emacs depends to glib,
and installing glib depends to python@3.9.
And to install python@3.9 conflicts
with already installed 2to3 on GitHub Actions macOS runner.
So remove 2to3 before operations.