### PR TITLE
Highlight too long line (over 80 chars) in C++ mode.

### DIFF
--- a/.emacs.d/my-init.el
+++ b/.emacs.d/my-init.el
@@ -241,6 +241,8 @@
   (add-to-list 'auto-mode-alist '("\\.h\\'" . c-mode))
   (add-to-list 'auto-mode-alist '("\\.mm\\'" . objc-mode))
   (font-lock-add-keywords 'c++-mode
+                          '(("^[^\n]\\{80\\}\\(.*\\)$" 1 font-lock-warning-face prepend)))
+  (font-lock-add-keywords 'c++-mode
                           '(("[ \t]+$" . 'trailing-whitespace)))
   (font-lock-add-keywords 'c-mode
                           '(("[ \t]+$" . 'trailing-whitespace)))


### PR DESCRIPTION
It is sometimes difficult to shorten the line in C,
because we avoid symbols' name conflictions without namespace.
So I don't apply this in C mode now.