### PR TITLE
chore: Update setup-scoop from @main to @v2.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
         key: cache_version_${{ env.cache_version }}-${{ runner.os }}-${{ hashFiles(env.cache_hash_seed_file_path) }}
 
     - name: Install scoop (Windows)
-      uses: MinoruSekine/setup-scoop@main
+      uses: MinoruSekine/setup-scoop@v2
       if: contains(matrix.os, 'windows') && steps.restore_cache.outputs.cache-hit != 'true'
       with:
         install_scoop: 'true'
@@ -76,7 +76,7 @@ jobs:
         update_path: 'true'
 
     - name: Setup scoop PATH (Windows)
-      uses: MinoruSekine/setup-scoop@main
+      uses: MinoruSekine/setup-scoop@v2
       if: contains(matrix.os, 'windows') && steps.restore_cache.outputs.cache-hit == 'true'
       with:
         install_scoop: 'false'


### PR DESCRIPTION
Now setup-scoop@v2 has officially been released
and it is including all latest features and fixes.