### PR TITLE
Revert "[Must be reverted] Disabled testrun for macOS by difficult error."

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
       run: ./.github/workflows/show_emacs_loadpath.sh
 
     - name: Test run
-      if: ${{ contains(matrix.os, 'ubuntu') }}
+      if: ${{ !contains(matrix.os, 'windows') }}
       shell: bash
       run: |
         make -k -j testrun


### PR DESCRIPTION


This reverts commit a4d1c638c0c79b7214adf1bb90d4b20480082908.