### PR TITLE
fix: ssh-agency warning on opening magit without any ssh keys (#343)

### DIFF
--- a/.emacs.d/my-init.el
+++ b/.emacs.d/my-init.el
@@ -679,7 +679,7 @@ and existing file includes no hard tab."
 (defun my-ssh-agency-setup ()
   "Setup ssh-agency."
   (when (package-installed-p 'ssh-agency)
-    (with-eval-after-load 'ssh-agency
+    (with-eval-after-load 'magit
       (unless (my-ssh-key-exists-p)
         (remove-hook 'magit-credential-hook 'ssh-agency-ensure)))))
 


### PR DESCRIPTION
Closes #343

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated credential hook configuration to optimize loading sequence in Emacs setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->