### PR TITLE
fix: Error on opening eshell without bash. (#344)

### DIFF
--- a/.emacs.d/my-init.el
+++ b/.emacs.d/my-init.el
@@ -646,7 +646,8 @@ and existing file includes no hard tab."
     (add-to-list 'eshell-visual-subcommands
                  '("git" "diff" "help" "log" "show")))
   (with-eval-after-load 'em-alias
-    (my-eshell-import-bash-aliases)))
+    (when (executable-find "bash")
+      (my-eshell-import-bash-aliases))))
 
 (defun my-emacs-lisp-mode-setup ()
   "Setup Emacs Lisp mode."


### PR DESCRIPTION
Closes #344

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where Emacs attempted to import shell aliases even when Bash was not installed on the system, preventing potential configuration errors during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->