### PR TITLE
fix: Too large fonts on Windows. (#347)

### DIFF
--- a/.emacs.d/my-init.el
+++ b/.emacs.d/my-init.el
@@ -695,15 +695,14 @@ and existing file includes no hard tab."
 
 (defun my-enabled-adjust-font-size-setup-p ()
   "Indicated necessary to adjust font size."
-  ;; NTEmacs seems to natively support high DPI awareness.
-  (and (not (equal system-type 'windows-nt))
-       (display-graphic-p)
+  (and (display-graphic-p)
        (display-supports-face-attributes-p :height)))
 
 (defun my-get-font-zoom-ratio-for-display ()
   "Get font zoom ratio for display."
   (if (my-enabled-adjust-font-size-setup-p)
-      (max (/ (my-get-display-dpi) 72) 1)
+      (let ((base-dpi (if (eq system-type 'windows-nt) 96.0 72.0)))
+        (max (/ (my-get-display-dpi) base-dpi) 1))
     1))
 
 (defun my-adjust-font-size (&optional frame)


### PR DESCRIPTION
Closes #347 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Font sizing now adapts to each operating system with proper DPI handling (96 DPI for Windows, 72 DPI for others)
  * Removed platform-specific font handling exceptions for more consistent rendering across systems
  * Simplified font initialization process by eliminating redundant operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->