### PR TITLE
fix: Error on installing magit by missing compat-31.

### DIFF
--- a/.emacs.d/my-init.el
+++ b/.emacs.d/my-init.el
@@ -300,6 +300,13 @@ and they will be ignored if using curl."
       (package-install 'gnu-elpa-keyring-update)
       (setq package-check-signature prev-package-check-signature)))
 
+  ;; compat-31 is necessary to install magit.
+  (unless (package-installed-p 'compat '(31))
+    (message "Upgrading compat ...")
+    (let ((package-check-signature nil))
+      (package-refresh-contents)
+      (package-upgrade 'compat)))
+
   (let* ((my-not-yet-installed-packages
           (cl-remove-if (lambda (p) (package-installed-p p))
                         my-packages)))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced package compatibility management by implementing automated version checks and updates for critical dependencies when network connectivity is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->