### PR TITLE
fix: "time" and "nice" appears in M-x compile default if unavailable

### DIFF
--- a/.emacs.d/my-init.el
+++ b/.emacs.d/my-init.el
@@ -583,11 +583,14 @@ and existing file includes no hard tab."
 (defun my-compilation-mode-setup ()
   "Setup compilation mode."
   (let* ((make-cmd (my-get-make-cmd))
-         (output-sync-opt (if (my-make-cmd-supports-output-sync-p make-cmd)
-                              "--output-sync"
-                            ""))
+         (cmds-list `(,@(when (executable-find "time") '("time"))
+                      ,@(when (executable-find "nice") '("nice"))
+                      ,make-cmd
+                      "-k" "-j"
+                      ,@(when (my-make-cmd-supports-output-sync-p make-cmd)
+                          '("--output-sync"))))
          (my-compile-command
-          (concat "time nice " make-cmd " -k -j " output-sync-opt)))
+          (mapconcat 'identity cmds-list " ")))
     (custom-set-variables
      '(compilation-scroll-output t)
      `(compile-command ,my-compile-command)))


### PR DESCRIPTION
Closes 358

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved compilation command construction with dynamic list-based building instead of static string concatenation.
  * Added optional performance wrappers (time, nice) when available.
  * Enhanced make compatibility with conditional output synchronization support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->