### PR TITLE
fix: Unnecessary check for  my-get-default-plantuml-jar-path. (#361)

### DIFF
--- a/.emacs.d/my-init.el
+++ b/.emacs.d/my-init.el
@@ -654,7 +654,7 @@ and existing file includes no hard tab."
         (when (executable-find java-path-installed-by-brew)
           (setq 'plantuml-java-command java-path-installed-by-brew))))
     (let* ((my-plantuml-jar-path (my-get-default-plantuml-jar-path)))
-      (when (file-exists-p my-plantuml-jar-path)
+      (when my-plantuml-jar-path
         (setq plantuml-jar-path my-plantuml-jar-path))
       ;; To avoid "No Java runtime present, requesting install." message
       ;; even if installed OpenJDK by brew.


### PR DESCRIPTION
Closes #361

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified PlantUML path validation in configuration setup.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MinoruSekine/dotfiles/pull/363)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->