### PR TITLE
fix: Unexpected dir for gnupg elpa keyring on Windows. (#371)

### DIFF
--- a/.emacs.d/my-init.el
+++ b/.emacs.d/my-init.el
@@ -289,7 +289,7 @@ and they will be ignored if using curl."
   ;; On Windows, absolute path in default package-gnupghome-dir
   ;; doesn't work fine with gpg.
   (when (equal system-type 'windows-nt)
-    (setq package-gnupghome-dir "elpa/gnupg"))
+    (setq package-gnupghome-dir "~/.emacs.d/elpa/gnupg/"))
   (require 'package)
   (add-to-list
    'package-archives


### PR DESCRIPTION
Closes #371

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package signature verification configuration on Windows systems by updating how the GnuPG home directory is located.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MinoruSekine/dotfiles/pull/372?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->