### PR TITLE
fix: PlantUML error on Windows.

### DIFF
--- a/.emacs.d/my-init.el
+++ b/.emacs.d/my-init.el
@@ -197,7 +197,7 @@ and they will be ignored if using curl."
                                   -1)))))
                 ((equal system-type 'windows-nt)
                  (expand-file-name (replace-regexp-in-string
-                                    "plantuml.\\(cmd\\|jar\\)\n"
+                                    "plantuml.\\(bat\\|cmd\\|jar\\)\n"
                                     "plantuml.jar"
                                     (shell-command-to-string
                                      (mapconcat


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed PlantUML jar path detection on macOS to properly recognize all Homebrew-installed formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->