### PR TITLE
ci: Trial for setup-scoop@v5. (#377)

### DIFF
--- a/.github/actions/install_emacs/action.yml
+++ b/.github/actions/install_emacs/action.yml
@@ -45,7 +45,7 @@ runs:
         brew install --cask emacs-app
 
     - name: Install scoop (Windows)
-      uses: MinoruSekine/setup-scoop@v4.0.2
+      uses: MinoruSekine/setup-scoop@main
       if: runner.os == 'Windows' && steps.restore_cache.outputs.cache-hit != 'true'
       with:
         install_scoop: 'true'
@@ -56,7 +56,7 @@ runs:
         apps: extras/emacs
 
     - name: Setup scoop PATH (Windows)
-      uses: MinoruSekine/setup-scoop@v4.0.2
+      uses: MinoruSekine/setup-scoop@main
       if: runner.os == 'Windows' && steps.restore_cache.outputs.cache-hit == 'true'
       with:
         install_scoop: 'false'


### PR DESCRIPTION
Closes #377

- In this PR, setup-scoop is targeted to `@main` because `@v5` planned changes in `main` branch but `v5` has not been tagged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration for Windows environment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->