### PR TITLE
ci: Update to use setup-scoop@v5 instead of @main. (#382)

### DIFF
--- a/.github/actions/install_emacs/action.yml
+++ b/.github/actions/install_emacs/action.yml
@@ -64,7 +64,7 @@ runs:
         brew install --cask emacs-app
 
     - name: Install scoop (Windows)
-      uses: MinoruSekine/setup-scoop@main
+      uses: MinoruSekine/setup-scoop@v5
       if: ${{ runner.os == 'Windows' && steps.check_cache_restored.outputs.restored != 'true' }}
       with:
         install_scoop: 'true'
@@ -75,7 +75,7 @@ runs:
         apps: extras/emacs
 
     - name: Setup scoop PATH (Windows)
-      uses: MinoruSekine/setup-scoop@main
+      uses: MinoruSekine/setup-scoop@v5
       if: ${{ runner.os == 'Windows' && steps.check_cache_restored.outputs.restored == 'true' }}
       with:
         install_scoop: 'false'


### PR DESCRIPTION
Closes #382

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the reliability and consistency of Windows environment setup.
  * Fresh installations and cached setups now follow the same stable configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->